### PR TITLE
hasNext and enum branch

### DIFF
--- a/src/main/java/org/staxnav/EnumElement.java
+++ b/src/main/java/org/staxnav/EnumElement.java
@@ -1,0 +1,10 @@
+package org.staxnav;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ * @version $Revision$
+ */
+public interface EnumElement<E extends Enum>
+{
+   String getLocalName();
+}

--- a/src/main/java/org/staxnav/Naming.java
+++ b/src/main/java/org/staxnav/Naming.java
@@ -106,15 +106,17 @@ public abstract class Naming<N>
       }
    }
 
-   public static class Enumerated<E extends Enum<E>> extends Naming<E>
+   public static class Enumerated<E extends Enum<E> & EnumElement<E>> extends Naming<E>
    {
 
       /** . */
       private final Class<E> enumType;
+      private final E noSuchElement;
 
-      public Enumerated(Class<E> enumType)
+      public Enumerated(Class<E> enumType, E noSuchElement)
       {
          this.enumType = enumType;
+         this.noSuchElement = noSuchElement;
       }
 
       @Override
@@ -126,12 +128,7 @@ public abstract class Naming<N>
       @Override
       protected String getLocalPart(E name)
       {
-         String s = name.name();
-         if (s.indexOf('_') >= 0)
-         {
-            s = s.replace('_', '-');
-         }
-         return s;
+         return name.getLocalName();
       }
 
       @Override
@@ -149,11 +146,15 @@ public abstract class Naming<N>
       @Override
       protected E getName(String uri, String prefix, String localPart)
       {
-         if (localPart.indexOf('-') != -1)
+         for (E e : enumType.getEnumConstants())
          {
-            localPart = localPart.replace('-', '_');
+            if (localPart.equals(e.getLocalName()))
+            {
+               return e;
+            }
          }
-         return Enum.valueOf(enumType, localPart);
+
+         return noSuchElement;
       }
    }
 }

--- a/src/main/java/org/staxnav/StaxNavigator.java
+++ b/src/main/java/org/staxnav/StaxNavigator.java
@@ -117,6 +117,13 @@ public interface StaxNavigator<N>
    boolean find(N name) throws StaxNavException;
 
    /**
+    * Indicates if there's more elements to be read. No navigation is performed.
+    *
+    * @return true if more elements can be read.
+    * @throws StaxNavException any StaxNavException
+    */
+   boolean hasNext() throws StaxNavException;
+   /**
     * Navigates to the next element and returns its name or null if the end of the stream is reached.
     *
     * @return the element name

--- a/src/main/java/org/staxnav/StaxNavigator.java
+++ b/src/main/java/org/staxnav/StaxNavigator.java
@@ -21,8 +21,6 @@ package org.staxnav;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.Location;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -106,9 +104,9 @@ public interface StaxNavigator<N>
    Iterable<StaxNavigator<N>> fork(N name);
 
    /**
-    * Attemps to navigate to an element following the current one when it has the specified name.
+    * Attempts to navigate to an element following the current one when it has the specified name.
     * If the navigation occurs, the navigator now points to that element and the method returns true.
-    * Otherwise no navigation happen and the method return false.
+    * Otherwise no navigation happens and the method returns false.
     *
     * @param name the element name to find
     * @return true if the desired element is reached
@@ -117,12 +115,13 @@ public interface StaxNavigator<N>
    boolean find(N name) throws StaxNavException;
 
    /**
-    * Indicates if there's more elements to be read. No navigation is performed.
+    * Indicates if there's more elements to be parsed. No navigation occurs.
     *
-    * @return true if more elements can be read.
+    * @return true if more elements can be parsed.
     * @throws StaxNavException any StaxNavException
     */
    boolean hasNext() throws StaxNavException;
+
    /**
     * Navigates to the next element and returns its name or null if the end of the stream is reached.
     *
@@ -134,7 +133,7 @@ public interface StaxNavigator<N>
    /**
     * Attempt to navigate to the next element when it has the specified name.
     * If the navigation occurs, the navigator now points to that element and the method returns true.
-    * Otherwise no navigation happen and the method return false.
+    * Otherwise no navigation happens and the method returns false.
     *
     * @param name the desired element name
     * @return true if the desired element is reached
@@ -146,7 +145,7 @@ public interface StaxNavigator<N>
    N next(Set<N> names) throws NullPointerException, StaxNavException;
 
    /**
-    * Attempts to navigate to the first child found and return its name. If no such child exist then null
+    * Attempts to navigate to the first child found and return its name. If no such child exists then null
     * is returned.
     *
     * @return the child name
@@ -157,7 +156,7 @@ public interface StaxNavigator<N>
    /**
     * Attempts to navigate to the first child with the specified name.
     * If the navigation occurs, the navigator now points to that element and the method returns true.
-    * Otherwise no navigation happen and the method return false.
+    * Otherwise no navigation happens and the method returns false.
     *
     *
     * @param name the child name
@@ -203,7 +202,7 @@ public interface StaxNavigator<N>
    /**
     * Attempts to navigate to the next sibling with the specified name.
     * If the navigation occurs, the navigator now points to that element and the method returns true.
-    * Otherwise no navigation happen and the method return false.
+    * Otherwise no navigation happens and the method returns false.
     *
     * @param name the next sibling name
     * @return true if the desired element is reached
@@ -215,7 +214,7 @@ public interface StaxNavigator<N>
    /**
     * Attempts to navigate to the first descendant with the specified name. The returned value should be interpreted as:
     * <ul>
-    * <li>a negative value means that no navigation occured</li>
+    * <li>a negative value means that no navigation occurred</li>
     * <li>any other value is the difference of depth between the two elements</li>
     * </ul>
     *

--- a/src/main/java/org/staxnav/StaxNavigatorImpl.java
+++ b/src/main/java/org/staxnav/StaxNavigatorImpl.java
@@ -31,7 +31,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -270,6 +269,11 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
          return null;
       }
       return current.getNamespaceByPrefix(prefix);
+   }
+
+   public boolean hasNext() throws StaxNavException
+   {
+      return current != null && current.hasNext();
    }
 
    public N next() throws StaxNavException
@@ -539,6 +543,8 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
 
       protected abstract String getNamespaceByPrefix(String namespacePrefix);
 
+      protected abstract boolean hasNext() throws StaxNavException;
+
       protected abstract Element next(int depth) throws StaxNavException;
 
       protected abstract Element next() throws StaxNavException;
@@ -632,6 +638,11 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
       protected String getNamespaceByPrefix(String namespacePrefix)
       {
          return get().getNamespaceByPrefix(namespacePrefix);
+      }
+
+      protected boolean hasNext() throws StaxNavException
+      {
+         return get().hasNext();
       }
 
       protected Element next(int depth) throws StaxNavException
@@ -869,6 +880,15 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
             }
          }
          return null;
+      }
+
+      protected boolean hasNext() throws StaxNavException
+      {
+         if (next == null)
+         {
+            next = next();
+         }
+         return next != null;
       }
 
       protected Element next(int depth) throws StaxNavException

--- a/src/main/java/org/staxnav/StaxNavigatorImpl.java
+++ b/src/main/java/org/staxnav/StaxNavigatorImpl.java
@@ -27,6 +27,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -273,7 +274,7 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
 
    public boolean hasNext() throws StaxNavException
    {
-      return current != null && current.hasNext();
+      return current != null && current.hasNext(depth);
    }
 
    public N next() throws StaxNavException
@@ -340,7 +341,13 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
       }
       else
       {
-         throw new StaxNavException(next.getLocation(), "Was expecting an element among " + names + " instead of " + name);
+         Set<String> localNames = new HashSet<String>(names.size());
+         for (N n : names)
+         {
+            localNames.add(naming.getLocalPart(n));
+         }
+
+         throw new StaxNavException(next.getLocation(), "Was expecting an element among " + localNames + " instead of " + naming.getLocalPart(name));
       }
    }
 
@@ -543,7 +550,7 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
 
       protected abstract String getNamespaceByPrefix(String namespacePrefix);
 
-      protected abstract boolean hasNext() throws StaxNavException;
+      protected abstract boolean hasNext(int depth) throws StaxNavException;
 
       protected abstract Element next(int depth) throws StaxNavException;
 
@@ -640,9 +647,9 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
          return get().getNamespaceByPrefix(namespacePrefix);
       }
 
-      protected boolean hasNext() throws StaxNavException
+      protected boolean hasNext(int depth) throws StaxNavException
       {
-         return get().hasNext();
+         return get().hasNext(depth);
       }
 
       protected Element next(int depth) throws StaxNavException
@@ -882,13 +889,9 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
          return null;
       }
 
-      protected boolean hasNext() throws StaxNavException
+      protected boolean hasNext(int depth) throws StaxNavException
       {
-         if (next == null)
-         {
-            next = next();
-         }
-         return next != null;
+         return next(depth) != null;
       }
 
       protected Element next(int depth) throws StaxNavException

--- a/src/main/java/org/staxnav/StaxNavigatorImpl.java
+++ b/src/main/java/org/staxnav/StaxNavigatorImpl.java
@@ -271,23 +271,22 @@ public class StaxNavigatorImpl<N> implements StaxNavigator<N>
       {
          return null;
       }
+
       Element next = current.next(depth);
-      if (next != null)
+      if (next == null)
       {
-         N name = naming.getName(next.getName());
-         if (names.contains(name))
-         {
-            current = next;
-            return name;
-         }
-         else
-         {
-            throw new StaxNavException(next.getLocation(), "Was not expecting an element among " + names + " instead of " + name);
-         }
+         return null;
+      }
+
+      N name = naming.getName(next.getName());
+      if (names.contains(name))
+      {
+         current = next;
+         return name;
       }
       else
       {
-         throw new StaxNavException(current.getLocation());
+         throw new StaxNavException(next.getLocation(), "Was expecting an element among " + names + " instead of " + name);
       }
    }
 

--- a/src/main/java/org/staxnav/ValueType.java
+++ b/src/main/java/org/staxnav/ValueType.java
@@ -19,6 +19,9 @@
 
 package org.staxnav;
 
+import javax.xml.bind.DatatypeConverter;
+import java.util.Date;
+
 /**
  * The type of a value.
  *
@@ -72,6 +75,24 @@ public abstract class ValueType<V>
       protected Integer parse(String s) throws Exception
       {
          return Integer.parseInt(s.trim());
+      }
+   };
+
+   public static final ValueType<Date> DATE = new ValueType<Date>()
+   {
+      @Override
+      protected Date parse(String s) throws Exception
+      {
+         return DatatypeConverter.parseDate(s).getTime();
+      }
+   };
+
+   public static final ValueType<Date> DATE_TIME = new ValueType<Date>()
+   {
+      @Override
+      protected Date parse(String s) throws Exception
+      {
+         return DatatypeConverter.parseDateTime(s).getTime();
       }
    };
 

--- a/src/test/java/org/staxnav/AbstractBrowseTestCase.java
+++ b/src/test/java/org/staxnav/AbstractBrowseTestCase.java
@@ -295,7 +295,7 @@ public abstract class AbstractBrowseTestCase<N> extends AbstractXMLTestCase
       while (navigator.next(names) != null)
       {
       }
-      assertEquals("foobar2", navigator.getName());
+      assertNameEquals("foobar2", navigator.getName());
       assertNull(navigator.next());
    }
 

--- a/src/test/java/org/staxnav/AbstractBrowseTestCase.java
+++ b/src/test/java/org/staxnav/AbstractBrowseTestCase.java
@@ -238,6 +238,47 @@ public abstract class AbstractBrowseTestCase<N> extends AbstractXMLTestCase
       assertEquals(-1, navigator.descendant(createName("blah")));
    }
 
+   public void testHasNext1() throws Exception
+   {
+      assertNameEquals("foo1", navigator.getName());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("bar1"), navigator.next());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("foo2"), navigator.next());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("bar2"), navigator.next());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("bar3"), navigator.next());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("foo3"), navigator.next());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("foobar1"), navigator.next());
+      assertTrue(navigator.hasNext());
+      assertEquals(createName("foobar2"), navigator.next());
+
+      assertFalse(navigator.hasNext());
+   }
+
+   public void testHasNext2() throws Exception
+   {
+      assertNameEquals("foo1", navigator.getName());
+      assertTrue(navigator.hasNext());
+
+      // Ensure navigation has not happened
+      assertNameEquals("foo1", navigator.getName());
+      assertEquals(1, navigator.getDepth());
+      assertTrue(navigator.child(createName("bar1")));
+
+      assertTrue(navigator.hasNext());
+
+      // Ensure navigation has not happened
+      assertNameEquals("bar1", navigator.getName());
+      assertEquals(2, navigator.getDepth());
+      assertTrue(navigator.sibling(createName("foobar2")));
+
+      assertFalse(navigator.hasNext());
+   }
+
    public void testNext1() throws Exception
    {
       assertNameEquals("foo1", navigator.getName());

--- a/src/test/java/org/staxnav/AbstractBrowseTestCase.java
+++ b/src/test/java/org/staxnav/AbstractBrowseTestCase.java
@@ -280,6 +280,24 @@ public abstract class AbstractBrowseTestCase<N> extends AbstractXMLTestCase
       }
    }
 
+   public void testNext4() throws Exception
+   {
+      assertNameEquals("foo1", navigator.getName());
+      Set<N> names = new HashSet<N>();
+      names.add(createName("bar1"));
+      names.add(createName("foo2"));
+      names.add(createName("bar2"));
+      names.add(createName("bar3"));
+      names.add(createName("foo3"));
+      names.add(createName("foobar1"));
+      names.add(createName("foobar2"));
+      while (navigator.next(names) != null)
+      {
+      }
+      assertEquals("foobar2", navigator.getName());
+      assertNull(navigator.next());
+   }
+
    public void testfind1() throws Exception
    {
       assertNameEquals("foo1", navigator.getName());

--- a/src/test/java/org/staxnav/EncodedNamingTestCase.java
+++ b/src/test/java/org/staxnav/EncodedNamingTestCase.java
@@ -1,0 +1,201 @@
+package org.staxnav;
+
+import javax.xml.namespace.QName;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
+ * @version $Revision$
+ */
+public class EncodedNamingTestCase extends StaxNavigatorTestCase
+{
+   private StaxNavigator<EncodedElement> navigator;
+
+   @Override
+   protected void setUp() throws Exception
+   {
+      navigator = navigator(new EncodedNaming(), "encoded.xml");
+   }
+
+   public void testNoSuchName()
+   {
+      assertTrue(navigator.next(EncodedElement.BOOK_ELEMENT));
+      assertEquals(EncodedElement.BOOK_ELEMENT, navigator.sibling());
+      assertEquals(EncodedElement.BOOK_ELEMENT, navigator.sibling());
+      assertEquals(EncodedElement.NOT_FOUND, navigator.next());
+   }
+
+   public void testValueType()
+   {
+      ValueType<String> decoderValueType = new ValueType<String>()
+      {
+         @Override
+         protected String parse(String s) throws Exception
+         {
+            return decode(s);
+         }
+      };
+      assertTrue(navigator.find(EncodedElement.TITLE_ELEMENT));
+      assertEquals("Title A", navigator.parseContent(decoderValueType));
+      assertEquals(EncodedElement.AUTHOR_ELEMENT, navigator.next());
+      assertEquals("Author A", navigator.parseContent(decoderValueType));
+
+      assertTrue(navigator.find(EncodedElement.TITLE_ELEMENT));
+      assertEquals("Title B", navigator.parseContent(decoderValueType));
+      assertEquals(EncodedElement.AUTHOR_ELEMENT, navigator.next());
+      assertEquals("Author B", navigator.parseContent(decoderValueType));
+
+      assertTrue(navigator.find(EncodedElement.TITLE_ELEMENT));
+      assertEquals("Title C", navigator.parseContent(decoderValueType));
+      assertEquals(EncodedElement.AUTHOR_ELEMENT, navigator.next());
+      assertEquals("Author C", navigator.parseContent(decoderValueType));
+   }
+
+   public void testForkMechanics()
+   {
+      assertEquals(EncodedElement.BOOKS_ELEMENT, navigator.getName());
+      assertEquals(EncodedElement.BOOK_ELEMENT, navigator.next());
+      int bookCount = 0;
+      for (StaxNavigator<EncodedElement> fork : navigator.fork(EncodedElement.BOOK_ELEMENT))
+      {
+         bookCount++;
+         int titleCount = 0;
+         int authorCount = 0;
+         int relatedBookCount = 0;
+         int relatedBookBookCount = 0;
+         int notFoundCount = 0;
+         while (fork.hasNext())
+         {
+            EncodedElement element = fork.next();
+            if (element.equals(EncodedElement.TITLE_ELEMENT))
+            {
+               titleCount++;
+            }
+            else if (element.equals(EncodedElement.AUTHOR_ELEMENT))
+            {
+               authorCount++;
+            }
+            else if (element.equals(EncodedElement.RELATED_ELEMENT))
+            {
+               relatedBookCount++;
+            }
+            else if (element.equals(EncodedElement.BOOK_ELEMENT))
+            {
+               relatedBookBookCount++;
+            }
+            else if (element.equals(EncodedElement.NOT_FOUND))
+            {
+               notFoundCount++;
+            }
+         }
+         assertEquals(1, titleCount);
+         assertEquals(1, authorCount);
+         assertEquals(1, relatedBookCount);
+         assertEquals(2, relatedBookBookCount);
+         assertEquals(1, notFoundCount);
+      }
+      assertEquals(3, bookCount);
+   }
+
+   private static class EncodedNaming extends Naming<EncodedElement>
+   {
+      @Override
+      String getLocalPart(EncodedElement name)
+      {
+         return name.encoded;
+      }
+
+      @Override
+      String getURI(EncodedElement name)
+      {
+         return null;
+      }
+
+      @Override
+      String getPrefix(EncodedElement name)
+      {
+         return null;
+      }
+
+      @Override
+      EncodedElement getName(QName name)
+      {
+         return (name == null) ? null : getName(name.getNamespaceURI(), name.getPrefix(), name.getLocalPart());
+      }
+
+      @Override
+      EncodedElement getName(String uri, String prefix, String localPart)
+      {
+         EncodedElement element = EncodedElement.MAP.get(localPart);
+
+         return (element != null) ? element : EncodedElement.NOT_FOUND;
+      }
+   }
+
+   private static class EncodedElement
+   {
+      private String encoded;
+      private String decoded;
+
+      EncodedElement(String localName)
+      {
+         encoded = localName;
+         decoded = decode(localName);
+      }
+
+      @Override
+      public int hashCode()
+      {
+         return decoded.hashCode();
+      }
+
+      @Override
+      public boolean equals(Object obj)
+      {
+         if (obj instanceof EncodedElement)
+         {
+            return decoded.equals(((EncodedElement) obj).decoded);
+         }
+         else
+         {
+            return super.equals(obj);
+         }
+      }
+
+      @Override
+      public String toString()
+      {
+         return decoded;
+      }
+
+      private static final EncodedElement BOOKS_ELEMENT = new EncodedElement(encode("books"));
+      private static final EncodedElement BOOK_ELEMENT = new EncodedElement(encode("book"));
+      private static final EncodedElement TITLE_ELEMENT = new EncodedElement(encode("title"));
+      private static final EncodedElement AUTHOR_ELEMENT = new EncodedElement(encode("author"));
+      private static final EncodedElement RELATED_ELEMENT = new EncodedElement(encode("related-books"));
+      private static final EncodedElement NOT_FOUND = new EncodedElement(encode("not-found"));
+
+      private static final Map<String, EncodedElement> MAP;
+
+      static {
+         Map<String, EncodedElement> map = new HashMap<String, EncodedElement>();
+         map.put(BOOKS_ELEMENT.encoded, BOOKS_ELEMENT);
+         map.put(BOOK_ELEMENT.encoded, BOOK_ELEMENT);
+         map.put(TITLE_ELEMENT.encoded, TITLE_ELEMENT);
+         map.put(AUTHOR_ELEMENT.encoded, AUTHOR_ELEMENT);
+         map.put(RELATED_ELEMENT.encoded, RELATED_ELEMENT);
+         MAP = map;
+      }
+   }
+
+   private static String decode(String encoded)
+   {
+      return new StringBuilder(encoded).reverse().toString();
+   }
+
+   private static String encode(String decoded)
+   {
+      return new StringBuilder(decoded).reverse().toString();
+   }
+}

--- a/src/test/java/org/staxnav/EnumeratedBrowseTestCase.java
+++ b/src/test/java/org/staxnav/EnumeratedBrowseTestCase.java
@@ -17,6 +17,8 @@ package org.staxnav;/*
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import java.util.Collections;
+
 /**
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  * @version $Revision$
@@ -27,6 +29,6 @@ public class EnumeratedBrowseTestCase extends AbstractBrowseTestCase<SampleName>
    @Override
    protected Naming<SampleName> getNaming()
    {
-      return new Naming.Enumerated<SampleName>(SampleName.class);
+      return new Naming.Enumerated<SampleName>(SampleName.class, SampleName.DONOTEXIST);
    }
 }

--- a/src/test/java/org/staxnav/NamespaceTestCase.java
+++ b/src/test/java/org/staxnav/NamespaceTestCase.java
@@ -50,16 +50,29 @@ public class NamespaceTestCase extends StaxNavigatorTestCase
       assertEquals("http://www.w3.org/2000/svg", navigator.getNamespaceByPrefix("ns"));
    }
 
-   static enum Name
+   static enum Name implements EnumElement<Name>
    {
-      foo, bar, juu
+      FOO("foo"), BAR("bar"), JUU("juu"), NOT_FOUND(null);
+
+      private String localName;
+
+      Name(String localName)
+      {
+         this.localName = localName;
+      }
+
+      public String getLocalName()
+      {
+         return localName;
+      }
    }
 
    public void testC() throws Exception
    {
-      StaxNavigator<Name> navigator = navigator(new Naming.Enumerated<Name>(Name.class), "namespace1.xml");
-      assertEquals(Name.foo, navigator.getName());
-      assertEquals(true, navigator.next(Name.bar));
+      StaxNavigator<Name> navigator = navigator(new Naming.Enumerated<Name>(Name.class, Name.NOT_FOUND), "namespace1.xml");
+      assertEquals(Name.FOO, navigator.getName());
+      assertEquals(true, navigator.next(Name.BAR));
+      assertEquals(Name.NOT_FOUND, navigator.next());
    }
 
    public void testD() throws Exception

--- a/src/test/java/org/staxnav/SampleName.java
+++ b/src/test/java/org/staxnav/SampleName.java
@@ -21,15 +21,26 @@ package org.staxnav;/*
  * @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a>
  * @version $Revision$
  */
-public enum SampleName
+public enum SampleName implements EnumElement<SampleName>
 {
 
-   foo1, foo2, foo3,
+   FOO1("foo1"), FOO2("foo2"), FOO3("foo3"),
 
-   bar1, bar2, bar3,
+   BAR1("bar1"), BAR2("bar2"), BAR3("bar3"),
 
-   foobar1, foobar2,
+   FOOBAR1("foobar1"), FOOBAR2("foobar2"),
 
-   donotexist, blah, bilto
+   DONOTEXIST("donotexist"), BLAH("blah"), BILTO("bilto");
 
+   private String localName;
+
+   SampleName(String localName)
+   {
+      this.localName = localName;
+   }
+
+   public String getLocalName()
+   {
+      return localName;
+   }
 }

--- a/src/test/resources/encoded.xml
+++ b/src/test/resources/encoded.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Characters are backwards, used for EncodedNamingTestCase example -->
+<skoob>
+   <koob>
+      <eltit>A eltiT</eltit>
+      <rohtua>A rohtuA</rohtua>
+      <skoob-detaler>
+         <koob>54321-1</koob>
+         <koob>43210-1</koob>
+         <nwonknu></nwonknu>
+      </skoob-detaler>
+   </koob>
+   <koob>
+      <eltit>B eltiT</eltit>
+      <rohtua>B rohtuA</rohtua>
+      <skoob-detaler>
+         <koob>54321-2</koob>
+         <koob>43210-2</koob>
+      </skoob-detaler>
+      <nwonknu></nwonknu>
+   </koob>
+   <koob>
+      <nwonknu></nwonknu>
+      <eltit>C eltiT</eltit>
+      <rohtua>C rohtuA</rohtua>
+      <skoob-detaler>
+         <koob>54321-3</koob>
+         <koob>43210-3</koob>
+      </skoob-detaler>
+   </koob>
+</skoob>

--- a/src/test/resources/namespace1.xml
+++ b/src/test/resources/namespace1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <foo xmlns="http://www.w3.org/TR/html4/">
   <bar></bar>
+  <bad-element></bad-element>
 </foo>


### PR DESCRIPTION
Julien here's what I was thinking in terms our Naming.Enumerated class.  The use of the EnumElement allows more control over the naming of the constants and xml elements.  And it's the responsibility of the Naming.getName methods to return a default value if no name is found.  In our case we let the developer distinguish this by passing it in the constructor of the Naming.Enumerated class.  I still think we should return null when there's no more content to parse.  I would rather have an NPE thrown in a switch statement then force people to catch some "NoMoreElements" exception just to know they are done parsing.  Typically in a switch you would have some loop anyways that should call the hasNext method.

The NamespaceTestCase.testC shows an example of the default enum value returned when an element not matching any enum is found in the xml.

Let me know what you think.
